### PR TITLE
Completed getting necesary fields from json

### DIFF
--- a/Angular-AMEALGOES/package.json
+++ b/Angular-AMEALGOES/package.json
@@ -23,7 +23,6 @@
     "@ng-bootstrap/ng-bootstrap": "^7.0.0",
     "bootstrap": "^4.5.2",
     "ngx-bootstrap": "^6.1.0",
-
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/Angular-AMEALGOES/src/app/services/google-maps-connection.service.spec.ts
+++ b/Angular-AMEALGOES/src/app/services/google-maps-connection.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GoogleMapsConnectionService } from './google-maps-connection.service';
+
+describe('GoogleMapsConnectionService', () => {
+  let service: GoogleMapsConnectionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GoogleMapsConnectionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/Angular-AMEALGOES/src/app/services/google-maps-connection.service.ts
+++ b/Angular-AMEALGOES/src/app/services/google-maps-connection.service.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GoogleMapsConnectionService {
+
+  constructor() { }
+}

--- a/Angular-AMEALGOES/src/app/services/google-maps-connection.service.ts
+++ b/Angular-AMEALGOES/src/app/services/google-maps-connection.service.ts
@@ -1,10 +1,110 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+//import { readFile } from 'fs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class GoogleMapsConnectionService {
 
-  constructor() { }
+
+
+  constructor() { 
+
+  console.log('In GoogleMapsConnectionService');
+
+}
+
+async getRestaurants(city: string) {
+
+  console.log('in getRestaurants()');
+
+  let a = 0;
+  let FileDirectory;
+
+
+  
+
+  if (city.toLowerCase().localeCompare(('new york'))==0){
+    FileDirectory = 'assets/philadelphia_json.txt';
+    console.log('its new york');
+
+  }
+
+  if (city.toLowerCase().localeCompare(('philadelphia'))==0){
+      FileDirectory = 'assets/new_york_JSON.txt';
+      console.log('its philly');
+  }
+
+  //let fr = new FileReader(); 
+  //let AllText = fr.readAsText(FileDirectory);
+
+//  console.log("fileDirectoryTest " + AllText);
+
+
+console.log('this is in fileDirectory '+FileDirectory);
+
+
+  return fetch(FileDirectory)
+  .then(response => response.text())
+  .then(text => {
+
+
+    console.log('this is in text '+text);
+    let fullResults = JSON.parse(text);
+
+    //console.log(fullResults.results[0]);
+
+    var list = [];
+
+    for(let i = 0; i<20; i++){
+
+      //console.log(fullResults.results[i].name);
+      let nameInJSON = fullResults.results[i].name;
+      //console.log(fullResults.results[i].vicinity);
+      let vicinityInJSON = fullResults.results[i].vicinity; 
+      //console.log(fullResults.results[i].place_id);
+      let idInJSON = fullResults.results[i].place_id;
+      
+      let restaurant = {
+        name: nameInJSON,
+        address:vicinityInJSON,
+        placeId:idInJSON
+      }
+
+      list[i] = restaurant;
+
+      console.log('error here? ');
+    }
+
+    for(let k = 0; k < 19; k++){
+      console.log('list info:' +list[k].name);
+    }
+    return list;
+ 
+    
+    //}).catch(error => {
+      //console.log('there was an error');
+    });
+
+
+
+
+
+  //console.log("this is a = " + a);
+  //console.log('is this printing??');
+//  console.log("TextInTxt2 " + textInTxt);
+
+
+
+  //fetch('assets/philadelphia_json.txt')
+  //.then(response => response.text())
+  //.then(text => console.log(text)); 
+
+
+
+}
+
+
+
 }

--- a/Angular-AMEALGOES/src/assets/new_york_JSON.txt
+++ b/Angular-AMEALGOES/src/assets/new_york_JSON.txt
@@ -1,0 +1,1038 @@
+{
+    "html_attributions": [],
+    "next_page_token": "CqQCHwEAAPCIakO_mquGbj5m-WpS1pFsIWuDA_-0VrvkONa06_3zNTxSDotZ8TpS01TTjTMJ9DeMM0MBdppa0NRX-5ixS8JrFDUF4deqfwFcB4Lb3SKoxeVadq_VWAP8072VWplMCn6GQzCPaEknkVDRcivvGVAAvbI48PVIYYMuaIFZ_FfXjlc8HEs65wFgoG81rF8_7sSQNlKWznT_AX9EfuP95bu2tNKx4v2vWnKyAwC5plMtYxnCljOREUWxOyZM5prExw5XJ-0cNqNXBvdScYucLFNibmQ0LY43PCO2uy_u-B-4Isr3IS5HldMBeOnT8lZVxQRZ6EY33MhsY_71iBKBuvV9AM34PJOfhxfwPqc7dQAY-MqPEdP7yrMPaFkjYjtYSxIQ6sqD-G5yNHbu845KjXRpdRoUm_6JYR346C-NGcaY0YddTVoJ3NE",
+    "results": [
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7198142,
+                    "lng": -74.00007339999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7212072802915,
+                        "lng": -73.99885581970848
+                    },
+                    "southwest": {
+                        "lat": 40.7185093197085,
+                        "lng": -74.0015537802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "NOMO SOHO",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 2184,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/105031608639159517170\">Oskar K. Wagner</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAlQ3pVUddIhZR07DatCVapovxRFcB4o5ZMZp_XhuLWcr4oDRpFs2ZCsWkt3NAF7UbmXAAD4FA6ohlEYNLoiwWUVO6Bb2WORmlX2rE7yZP5gx-GA74p1HiygUCWCmPXMu7EhDl_nckXDrDxmbBxSPOA7VYGhRwaqCzdYrrNeANC4iJ1xgo9d4Byg",
+                    "width": 4608
+                }
+            ],
+            "place_id": "ChIJM8mGj4lZwokRSbZBvNOVNKM",
+            "plus_code": {
+                "compound_code": "PX9X+WX New York, NY, USA",
+                "global_code": "87G7PX9X+WX"
+            },
+            "price_level": 3,
+            "rating": 4.2,
+            "reference": "ChIJM8mGj4lZwokRSbZBvNOVNKM",
+            "scope": "GOOGLE",
+            "types": [
+                "meal_takeaway",
+                "lodging",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1146,
+            "vicinity": "9 Crosby Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.679225,
+                    "lng": -73.98316200000001
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.68049833029149,
+                        "lng": -73.9818237697085
+                    },
+                    "southwest": {
+                        "lat": 40.67780036970849,
+                        "lng": -73.9845217302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "Union Hotel, Ascend Hotel Collection",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 1638,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/107576589143997416395\">Union Hotel, Ascend Hotel Collection</a>"
+                    ],
+                    "photo_reference": "CmRaAAAA8mRoyn9ReKZRwUhQ6rK2JMCLQQJ69jbZeAhDryJU9QhfbuFctvT7wJLIioAeNar2jTa1sXc3jKYvq4YRfxDl-LX8fHSK5JBFBPY-509oDdXACAEz6RkC_E6z_2rBy20BEhCkVAvwOt3_KXQEZFtr1IGaGhT3EL5fzPwzigdgfi7pVDT7kC-5kQ",
+                    "width": 2640
+                }
+            ],
+            "place_id": "ChIJNw_kzFRawokRESt-098Pb7Q",
+            "plus_code": {
+                "compound_code": "M2H8+MP New York, NY, USA",
+                "global_code": "87G8M2H8+MP"
+            },
+            "rating": 3.2,
+            "reference": "ChIJNw_kzFRawokRESt-098Pb7Q",
+            "scope": "GOOGLE",
+            "types": [
+                "lodging",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 383,
+            "vicinity": "611 Degraw Street, Brooklyn"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7557052,
+                    "lng": -73.981849
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7572832302915,
+                        "lng": -73.9803626697085
+                    },
+                    "southwest": {
+                        "lat": 40.7545852697085,
+                        "lng": -73.9830606302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "Sofitel New York",
+            "photos": [
+                {
+                    "height": 2413,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/103459388932264757090\">Sofitel New York</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAmnK3c-fmZyKwQvY_fUB76iyIVjRz0QDY4lJxJfEr3jtikVbYsbE7YcD_gmHMlJIsLmPUAYwI2kRlZ6GR1ROF79nnqHoVdGKn2n2K8ia7x5r6VCgnAYgis5gzQkdF8iY9EhArMWEXylyNdhvcRtAD6eHgGhQ2p3VOA4dN5ipL2rTGiSiuI2ncUQ",
+                    "width": 3620
+                }
+            ],
+            "place_id": "ChIJ5Zpl7_9YwokRFePhP7971nc",
+            "plus_code": {
+                "compound_code": "Q249+77 New York, NY, USA",
+                "global_code": "87G8Q249+77"
+            },
+            "price_level": 3,
+            "rating": 4.5,
+            "reference": "ChIJ5Zpl7_9YwokRFePhP7971nc",
+            "scope": "GOOGLE",
+            "types": [
+                "lodging",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1466,
+            "vicinity": "45 West 44th Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.76278840000001,
+                    "lng": -73.9836945
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7641838302915,
+                        "lng": -73.98231071970848
+                    },
+                    "southwest": {
+                        "lat": 40.7614858697085,
+                        "lng": -73.9850086802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "Novotel New York Times Square",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 1192,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/113335589562963828073\">Novotel New York Times Square</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAzjYupZ1xpjhtlAUrbAvqNJk85lOLAuEOMfhoJp3EKeKDCRZ-xR4_lWq4emP1qIhRokHBqYY2tt4XAcXnvA7dxSs-QK0QoqJT9RTp08b78BNyk9gGuD30Imjn8sFR5w4BEhBDylojEuSb2zUCBklxLaCBGhSapjDTQ6ni05MmIKANNXRUhI5ILQ",
+                    "width": 2119
+                }
+            ],
+            "place_id": "ChIJr9cp0ldYwokRxolUb1zQPzE",
+            "plus_code": {
+                "compound_code": "Q278+4G New York, NY, USA",
+                "global_code": "87G8Q278+4G"
+            },
+            "rating": 4.4,
+            "reference": "ChIJr9cp0ldYwokRxolUb1zQPzE",
+            "scope": "GOOGLE",
+            "types": [
+                "lodging",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 3566,
+            "vicinity": "226 West 52nd Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.76573249999999,
+                    "lng": -73.96922619999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7671667302915,
+                        "lng": -73.96782901970849
+                    },
+                    "southwest": {
+                        "lat": 40.7644687697085,
+                        "lng": -73.97052698029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "The Lowell Hotel",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3456,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/109242289716376687889\">The Lowell Hotel</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAqE5RS3utN2OmJs7JFrdCY5iEAh99N1TOdRWOhR9yrpKgwEn-pbbw49Aw18od0hURpJUgf3odDcd4ExRkOD0L2SxtdBlJq43SragKns83iYPHHfuCQgZuTQNCh4UrelQOEhC06g-jSxpR8RDeZ-G0q874GhTTddDHeSuaxzhbxUv_OzIuUEwxOQ",
+                    "width": 5184
+                }
+            ],
+            "place_id": "ChIJb9nOTe5YwokR5og3CprlOX4",
+            "plus_code": {
+                "compound_code": "Q28J+78 New York, NY, USA",
+                "global_code": "87G8Q28J+78"
+            },
+            "price_level": 3,
+            "rating": 4.6,
+            "reference": "ChIJb9nOTe5YwokR5og3CprlOX4",
+            "scope": "GOOGLE",
+            "types": [
+                "night_club",
+                "lodging",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 246,
+            "vicinity": "28 East 63rd Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7752711,
+                    "lng": -73.9633994
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7765714302915,
+                        "lng": -73.96208626970851
+                    },
+                    "southwest": {
+                        "lat": 40.77387346970851,
+                        "lng": -73.96478423029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "The Mark Hotel",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3403,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/113932043824166121037\">The Mark Hotel</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAikgeG9eOvqYVEuemUmzozVr55apnyal6ih0l8J_vA03Mo0VM6dGuzEz2fpctM0ND7SCZOA6yCphByRprwUixukbnl-Rl2QacGImhAF94u9DdS3t-kxE1INY36CkX_wmQEhDvaSN99UFJrcgy736SFSxxGhR9bmC-tAKIw3ZgefQq32zV3cXDfg",
+                    "width": 5026
+                }
+            ],
+            "place_id": "ChIJXYOiRJRYwokRm1i3c9R6WDA",
+            "plus_code": {
+                "compound_code": "Q2GP+4J New York, NY, USA",
+                "global_code": "87G8Q2GP+4J"
+            },
+            "rating": 4.6,
+            "reference": "ChIJXYOiRJRYwokRm1i3c9R6WDA",
+            "scope": "GOOGLE",
+            "types": [
+                "lodging",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 597,
+            "vicinity": "25 East 77th Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7573681,
+                    "lng": -73.9835798
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7586323302915,
+                        "lng": -73.9823113197085
+                    },
+                    "southwest": {
+                        "lat": 40.75593436970851,
+                        "lng": -73.98500928029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Connolly's Pub & Restaurant",
+            "photos": [
+                {
+                    "height": 3193,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/107545232598166074128\">Jerry Lipchus</a>"
+                    ],
+                    "photo_reference": "CmRaAAAASJv0saieqrON0bz4asaRKJGHjo_-anDXoZfuWTZgkiXm47p0QlOPeswuD0ftnb_vPmVnbj5SH1jpVJtD6VNmzSBRJ8uxNh2g__ZeK6JSJc0OY1gBZlwBHuEYj16aq2m7EhB6MQ_AzvTeY9dk9QvWeRMiGhRN5XuSJhEKayXFr-xummotFSDUCQ",
+                    "width": 2913
+                }
+            ],
+            "place_id": "ChIJAS6GeVVYwokRPfg8xt4nH-I",
+            "plus_code": {
+                "compound_code": "Q248+WH New York, NY, USA",
+                "global_code": "87G8Q248+WH"
+            },
+            "price_level": 2,
+            "rating": 4.4,
+            "reference": "ChIJAS6GeVVYwokRPfg8xt4nH-I",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2387,
+            "vicinity": "121 West 45th Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.73,
+                    "lng": -74.00072779999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7312968802915,
+                        "lng": -73.99931421970849
+                    },
+                    "southwest": {
+                        "lat": 40.7285989197085,
+                        "lng": -74.0020121802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Artichoke Basille's Pizza",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 4032,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/105280946035097287477\">Crissi Beth</a>"
+                    ],
+                    "photo_reference": "CmRaAAAADesLAXhfBou10NCDawg7TdXHyxBBch-WbOCCwUcT7aGMudOM-gVhKY9PE0No5YFqTmKRG3um-wq4U2WON3ufSHU_E9Zwl51SI1p30bF-O9056myJesg8QzJrjksV8AsEEhB75yRYwPlO_rXHhjgKwxm-GhRKPjYQc6z_6gTl3K3Y00sjI-B-6Q",
+                    "width": 3024
+                }
+            ],
+            "place_id": "ChIJ10EpKJJZwokRUjIWaunOQbI",
+            "plus_code": {
+                "compound_code": "PXHX+XP New York, NY, USA",
+                "global_code": "87G7PXHX+XP"
+            },
+            "price_level": 2,
+            "rating": 4.4,
+            "reference": "ChIJ10EpKJJZwokRUjIWaunOQbI",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1283,
+            "vicinity": "111 MacDougal Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7163226,
+                    "lng": -73.98864949999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7177430802915,
+                        "lng": -73.9872212197085
+                    },
+                    "southwest": {
+                        "lat": 40.7150451197085,
+                        "lng": -73.98991918029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Doughnut Plant",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3456,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/100710582808001273786\">Doughnut Plant</a>"
+                    ],
+                    "photo_reference": "CmRaAAAASBITLOJmnz6i22p2jXJccK8HxLxY2E3C_qndh_q1qwmoqUH4eivWkofOG3GTim2HVbnEWxY76gL5-J16tqZ1GnUqzgQMCXcBUiWuIjZMs3M1G6EbSTZD1IxRl0-Io-mWEhAP5Tof_rGPrRCrPLtRpohWGhRs0rGRu62_abttRXN4tCJVaW2TOQ",
+                    "width": 5184
+                }
+            ],
+            "place_id": "ChIJ2SZLBypawokR5g0jFxaMY10",
+            "plus_code": {
+                "compound_code": "P286+GG New York, NY, USA",
+                "global_code": "87G8P286+GG"
+            },
+            "price_level": 2,
+            "rating": 4.5,
+            "reference": "ChIJ2SZLBypawokR5g0jFxaMY10",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "cafe",
+                "food",
+                "point_of_interest",
+                "store",
+                "establishment"
+            ],
+            "user_ratings_total": 1708,
+            "vicinity": "379 Grand Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7038114,
+                    "lng": -73.9947222
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7051265802915,
+                        "lng": -73.99333631970849
+                    },
+                    "southwest": {
+                        "lat": 40.7024286197085,
+                        "lng": -73.9960342802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "The River Café",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 1200,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/110287755892943639196\">The River Café</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAuA41ZZ4GR6Ui0sDCbPOWNSIWZ9gOK3-J-yMISCpG1AlS6kF8dDFLzi_FW2NZJToIKKBLlE_ikNq3f1LsYHoUGOhOcczaLwboOSG-94Df0UCxFIMpSDUbxeZ_64iIeSlMEhDHad1m_kGsOQrC2ap7hJOzGhSuQXSTsilRdIUOTiaQdXsEOsYn5w",
+                    "width": 1800
+                }
+            ],
+            "place_id": "ChIJ2QZOdTpawokRU_eN_EPJaX8",
+            "plus_code": {
+                "compound_code": "P234+G4 Brooklyn, NY, USA",
+                "global_code": "87G8P234+G4"
+            },
+            "price_level": 4,
+            "rating": 4.5,
+            "reference": "ChIJ2QZOdTpawokRU_eN_EPJaX8",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1575,
+            "vicinity": "1 Water Street, Brooklyn"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7606967,
+                    "lng": -74.01803629999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7621391802915,
+                        "lng": -74.01689026970848
+                    },
+                    "southwest": {
+                        "lat": 40.7594412197085,
+                        "lng": -74.0195882302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Chart House",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 2406,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/105303505373661530610\">indoorfish</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAxIL8aQrqA2Sn8uj8uQ2C0Fest6dfxH5eeg6mXmrL4dGAXRmgw6rMW9yfSesgFCwLOQLoscpPtVLtWygkSe5w5R7-mBf-LA5f-xVZ-x8wPVS1lTwjX95NSJhR-UXrXjJTEhA0VqrsVwP-gcBKLN1DT66TGhSrI2A4qy9nF_NSLlzhfoqigSMJmw",
+                    "width": 3600
+                }
+            ],
+            "place_id": "ChIJfSrfpzJYwokRZK7ZRue5tG8",
+            "plus_code": {
+                "compound_code": "QX6J+7Q Weehawken, NJ, USA",
+                "global_code": "87G7QX6J+7Q"
+            },
+            "price_level": 3,
+            "rating": 4.5,
+            "reference": "ChIJfSrfpzJYwokRZK7ZRue5tG8",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 4192,
+            "vicinity": "1700 Harbor Boulevard, Weehawken"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.70412899999999,
+                    "lng": -74.010336
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7054283302915,
+                        "lng": -74.00892606970851
+                    },
+                    "southwest": {
+                        "lat": 40.7027303697085,
+                        "lng": -74.01162403029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Beckett's Bar & Grill",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 450,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/101159933384907907290\">Beckett&#39;s Bar &amp; Grill</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAjJzgnhCQYL4yCH_iO6VqkUYIo-i5CUT2sDtiQSHW4yRbfjW8fjLYyz17_mMjj50bR-nVVytBGElx8jzBea1jsk-8bOej_m1HXDFEtPezhj-n3woXEfXpsXBakV0q0dRGEhAIhGw1LTbUfWB0d4HwkHaDGhQoa0Ezyfcdauqy5nAxfucnVN2xTg",
+                    "width": 800
+                }
+            ],
+            "place_id": "ChIJ3blcJRRawokRex4mbeb9Ix4",
+            "plus_code": {
+                "compound_code": "PX3Q+MV New York, NY, USA",
+                "global_code": "87G7PX3Q+MV"
+            },
+            "price_level": 2,
+            "rating": 4.1,
+            "reference": "ChIJ3blcJRRawokRex4mbeb9Ix4",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 328,
+            "vicinity": "81 Pearl Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7358805,
+                    "lng": -74.00496729999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7372201302915,
+                        "lng": -74.00369426970849
+                    },
+                    "southwest": {
+                        "lat": 40.7345221697085,
+                        "lng": -74.00639223029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Magnolia Bakery - West Village",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3456,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/110998140459284225124\">Magnolia Bakery - West Village</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAEVkBDdF-IhHJ1hZYbHL4eC9rh5otudB_iL-8FoFXQJq4KW8KPjFKem9gRzOtzASZQlVtGSIiGk4bvKpAaqmZrkLxrB2VaUoJHsQ-0zSIUWKKULMhbbGdnNavUnMFqB_gEhC7z_V02j9SJAUWaBG_MTTpGhQ_PjThCZ_kPJ-t5nh9bkb6h4Zsgw",
+                    "width": 5184
+                }
+            ],
+            "place_id": "ChIJF9Du35RZwokRFGd0oc4diZs",
+            "plus_code": {
+                "compound_code": "PXPW+92 New York, NY, USA",
+                "global_code": "87G7PXPW+92"
+            },
+            "price_level": 2,
+            "rating": 4.4,
+            "reference": "ChIJF9Du35RZwokRFGd0oc4diZs",
+            "scope": "GOOGLE",
+            "types": [
+                "bakery",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "store",
+                "establishment"
+            ],
+            "user_ratings_total": 2618,
+            "vicinity": "West 11th Street, 401 Bleecker Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7303928,
+                    "lng": -73.9830491
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7317740302915,
+                        "lng": -73.9817768197085
+                    },
+                    "southwest": {
+                        "lat": 40.7290760697085,
+                        "lng": -73.98447478029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Kikoo Sushi",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 809,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/108034232279696785031\">Kikoo Sushi(formerly Kumo Sushi)</a>"
+                    ],
+                    "photo_reference": "CmRaAAAALjDfvQ8wGeeG8MJ3_Wosjy9N_Qnm02dtv3d5250aTDbse3SrAGU7CCV8bzrmZOVwh2vZtuddkhOTG5guyZlgJ9VVMOOJdK3Smacu69784QmsA3WNyzLjHWxPPJPXoGfgEhADhR6zr4DSjBIgATrThNWeGhTftvAsKhXFwUHJI5L0odW-cmlvbg",
+                    "width": 1440
+                }
+            ],
+            "place_id": "ChIJ5f-M_3VZwokRMez6xx0wcio",
+            "plus_code": {
+                "compound_code": "P2J8+5Q New York, NY, USA",
+                "global_code": "87G8P2J8+5Q"
+            },
+            "price_level": 2,
+            "rating": 4.7,
+            "reference": "ChIJ5f-M_3VZwokRMez6xx0wcio",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 688,
+            "vicinity": "210 1st Avenue, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.74296950000001,
+                    "lng": -73.98938579999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7444374802915,
+                        "lng": -73.9880309697085
+                    },
+                    "southwest": {
+                        "lat": 40.7417395197085,
+                        "lng": -73.99072893029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/bar-71.png",
+            "name": "The 40/40 Club",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/118418239486822996379\">24 Hours</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAHXvV0Zk7NkM_FW8gsiWMjPd07YPW0RfUimdwfWXzRLcFKsrnKAdxuS0zxwwnwONER3Udg3YX-_yjBIVNfhAA5JbxBJIxZNGMbPKAJE_L9541Bjs9jVhmPRY-aCyzK32BEhCbhGZFsfrlKnuoFe1psd-1GhRyflYxapauyT9cAKqxzT_meYZK4w",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJ-8qQJaRZwokROBJmbLfbWDg",
+            "plus_code": {
+                "compound_code": "P2V6+56 New York, NY, USA",
+                "global_code": "87G8P2V6+56"
+            },
+            "price_level": 3,
+            "rating": 4.1,
+            "reference": "ChIJ-8qQJaRZwokROBJmbLfbWDg",
+            "scope": "GOOGLE",
+            "types": [
+                "night_club",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1268,
+            "vicinity": "6 West 25th Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7514762,
+                    "lng": -73.9883517
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.75291758029151,
+                        "lng": -73.9869349697085
+                    },
+                    "southwest": {
+                        "lat": 40.75021961970851,
+                        "lng": -73.98963293029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Lan Sheng",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/104305600353232127475\">Chika Ehirim</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAm_jR9X6Kl9PjyudgbDJrY1b4x1SUIrXYAXe5al-leTRrMiWvQqkxMcQBWVeCPiK63fXkuajDzjJ0t5RLQf26ERVVevO2D86F-OJ1UbWqu0H9ZKPfOc_QM2W6-6n6T2pFEhA0NqOeftyji-g208owwSFiGhQ9SUy8kbN6JVJpowsu6FWJZwElFg",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJM6NLWapZwokR5Gj7tgBAfWo",
+            "plus_code": {
+                "compound_code": "Q226+HM New York, NY, USA",
+                "global_code": "87G8Q226+HM"
+            },
+            "price_level": 2,
+            "rating": 4,
+            "reference": "ChIJM6NLWapZwokR5Gj7tgBAfWo",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 468,
+            "vicinity": "128 West 36th Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7626593,
+                    "lng": -73.97144110000001
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.76405543029149,
+                        "lng": -73.9700506697085
+                    },
+                    "southwest": {
+                        "lat": 40.76135746970849,
+                        "lng": -73.97274863029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "TAO Uptown",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 1402,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/111193428587917886143\">TAO Uptown</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAjn_jAWsKXDfACawdEKNDQbiAGofisGyjeTbW65CQ2DafwZfpD3FrfuHJAwKplbZLwXw95sBEc7RqMA407P7rU1lPphA0ZMWUUs69Fv6cZl9K9oWetk4TmWae0EVkGKf6EhBkEQx3G2E-GvrHNINFtBfVGhSwiRnnDwV7gC-RSdVbFsFhYbqd5g",
+                    "width": 2048
+                }
+            ],
+            "place_id": "ChIJh3qVsvpYwokRVtJoHuKeQ3M",
+            "plus_code": {
+                "compound_code": "Q27H+3C New York, NY, USA",
+                "global_code": "87G8Q27H+3C"
+            },
+            "price_level": 3,
+            "rating": 4.3,
+            "reference": "ChIJh3qVsvpYwokRVtJoHuKeQ3M",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2648,
+            "vicinity": "42 East 58th Street, New York"
+        },
+        {
+            "business_status": "CLOSED_TEMPORARILY",
+            "geometry": {
+                "location": {
+                    "lat": 40.7422779,
+                    "lng": -73.98374969999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7436811302915,
+                        "lng": -73.98243406970848
+                    },
+                    "southwest": {
+                        "lat": 40.7409831697085,
+                        "lng": -73.9851320302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Blue Smoke",
+            "permanently_closed": true,
+            "photos": [
+                {
+                    "height": 2592,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/106738208508741642175\">Blue Smoke</a>"
+                    ],
+                    "photo_reference": "CmRaAAAARh8_-YOmZi6DRoh76YbiDAlQSLNl_cRasmD2LGRv5LrKLOiApB-RdZHLy4Kse_jRrZodJaDQni-OSQGHCvlFVWPBX1eNrW3svMkevhgDlZa5BA89B987q6Ml5p-wDrk4EhBwwMzwgYBigSN11vYv_uwFGhSecoD3vSlNp-pzopEvlf_Ns9JALQ",
+                    "width": 3888
+                }
+            ],
+            "place_id": "ChIJu0Tob6dZwokRFjJdOBK-xMU",
+            "plus_code": {
+                "compound_code": "P2R8+WG New York, NY, USA",
+                "global_code": "87G8P2R8+WG"
+            },
+            "price_level": 3,
+            "rating": 4.4,
+            "reference": "ChIJu0Tob6dZwokRFjJdOBK-xMU",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1976,
+            "vicinity": "116 East 27th Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.7605396,
+                    "lng": -73.9774216
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7617647302915,
+                        "lng": -73.97614871970849
+                    },
+                    "southwest": {
+                        "lat": 40.7590667697085,
+                        "lng": -73.97884668029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "21 Club",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 1356,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/100691634387600446654\">21 Club</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAAVsbFd5uxS0sVrQcfPwK-txFSoauwKNtr8jaRKgWP-Ww6zahCI7k9mQDpIKzmyIlV7HGbf1I6LRMy11HCv2FdJ4oh4klsxLV6BrJ7hcfTzO0qAilxV6sbD_0NjeZfTrUEhA2xlbGGouV70Ef0HZvPSFjGhQLXdmV2mLqGiBwlJcFDVXa22bUAg",
+                    "width": 2240
+                }
+            ],
+            "place_id": "ChIJpZepXflYwokRNuSe6xAwprw",
+            "plus_code": {
+                "compound_code": "Q26F+62 New York, NY, USA",
+                "global_code": "87G8Q26F+62"
+            },
+            "price_level": 4,
+            "rating": 4.4,
+            "reference": "ChIJpZepXflYwokRNuSe6xAwprw",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 851,
+            "vicinity": "21 West 52nd Street, New York"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 40.757498,
+                    "lng": -73.986654
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 40.7589056302915,
+                        "lng": -73.98532551970851
+                    },
+                    "southwest": {
+                        "lat": 40.7562076697085,
+                        "lng": -73.98802348029152
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Carmine's Italian Restaurant",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 1080,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/107712532148225729261\">Carmine&#39;s Italian Restaurant</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAcbWCQRHTeanj7WG16vfrUnpGfQEyrHN5e_aprdlp_Offtl7ZvQJBDpl_I4RESrH4wS0CRHAIZXRL97MXgjwv21pVmROva-ZZuPBRMpgZEskp52s1tVsm18cTjYE1CDAiEhC6sARzKs3W0veb5z5FoSkZGhS5Cn5oZfie0lFxHxoi2YTNs3i5pQ",
+                    "width": 1920
+                }
+            ],
+            "place_id": "ChIJR9So-lRYwokRX1xEjA0rChA",
+            "plus_code": {
+                "compound_code": "Q247+X8 New York, NY, USA",
+                "global_code": "87G8Q247+X8"
+            },
+            "price_level": 2,
+            "rating": 4.5,
+            "reference": "ChIJR9So-lRYwokRX1xEjA0rChA",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 10986,
+            "vicinity": "200 West 44th Street, New York"
+        }
+    ],
+    "status": "OK"
+}

--- a/Angular-AMEALGOES/src/assets/philadelphia_json.txt
+++ b/Angular-AMEALGOES/src/assets/philadelphia_json.txt
@@ -1,0 +1,1045 @@
+{
+    "html_attributions": [],
+    "next_page_token": "CqQCHwEAAGQi0BfvFFgz4yX8ttdMgm9jrss6cNDcKVNW6vM4g5xR9rk-yM9FuJbmFEK8tnN1IakwvZbEWPBTEGRfHLOpbAsZe4cuZSOdi-XhDQZE_YhGyDj_T7L8EFkUnoVt5omqCVM_vCSqXVQ0IIicLbNR3lnggsDPNafM7kbfZlX5EPj2wU-cI_3jUi6DR0-yoGPTJOHXDtipdlcP-hf4gUnSjm65Plznx5qdWXe2ZH4lZ-95Ce0q2NxczeJBV_Cl1TalFW9ERuqWZ0uiA__LJ8k42QTXyZIrJRio91SThtENq3k-MLTaS29w5LJrJcvh6no78dRZm9FaGGouf0xWKGN4N1wNf94RpK4Dt6NILKNelfkkUUoODMo7B7EqdrL4zxlYHhIQlzwQkJyZRbKwGhFzR8C73xoUcqpF8Od9GHxUrDDMgeijILq3j1E",
+    "results": [
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9507723,
+                    "lng": -75.1690167
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9521472802915,
+                        "lng": -75.1676251697085
+                    },
+                    "southwest": {
+                        "lat": 39.9494493197085,
+                        "lng": -75.17032313029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "Hotel Sofitel Philadelphia at Rittenhouse Square",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 768,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/114227411825662988006\">Hotel Sofitel Philadelphia at Rittenhouse Square</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAeAHaa8AoyZbi1hp7IBMoygYUqY6VtohIHhL30WS3yjt07nucJGCCshihCfky3E3DwFKK7e-bvgiucwk5RlqrFFgQNwmY71cLXIP4IexVxOiiQDPFIvJM8ARlSQGLZIxHEhCfufGpLON2TI0OuRxfYYCdGhSgbokRm12ZtANW7sqEcA0WKCZcnQ",
+                    "width": 1024
+                }
+            ],
+            "place_id": "ChIJrQbSYzDGxokR2TCy3fjNWoQ",
+            "plus_code": {
+                "compound_code": "XR2J+89 Philadelphia, PA, USA",
+                "global_code": "87F6XR2J+89"
+            },
+            "price_level": 3,
+            "rating": 4.5,
+            "reference": "ChIJrQbSYzDGxokR2TCy3fjNWoQ",
+            "scope": "GOOGLE",
+            "types": [
+                "lodging",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1829,
+            "vicinity": "120 South 17th Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.949831,
+                    "lng": -75.1732573
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.95114993029149,
+                        "lng": -75.17186766970849
+                    },
+                    "southwest": {
+                        "lat": 39.94845196970849,
+                        "lng": -75.17456563029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "The Rittenhouse Hotel",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/100582896727820392067\">Art MacNew</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAYUhUwXWXr2GIO7NpD1SC-nBTxFeDXct9YFB-UmLoFOaPIHphqtm_teJoDsmFtgdi2Dawcjo-1Xe8p3fRdIvQLSNAE9200uj7UQtbAeokEUBY3CNZKRTYWx8er4Pc_ejdEhDaLgcByOCRCL8O2Tp2AJlTGhS_jz8QLlBlxSy5DcbgjKDbFOh6WQ",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJBZC45TnGxokRo_XAGoh5C30",
+            "plus_code": {
+                "compound_code": "WRXG+WM Philadelphia, PA, USA",
+                "global_code": "87F6WRXG+WM"
+            },
+            "price_level": 3,
+            "rating": 4.6,
+            "reference": "ChIJBZC45TnGxokRo_XAGoh5C30",
+            "scope": "GOOGLE",
+            "types": [
+                "spa",
+                "lodging",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 775,
+            "vicinity": "210 West Rittenhouse Square, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9506255,
+                    "lng": -75.1635909
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9520309802915,
+                        "lng": -75.1623906697085
+                    },
+                    "southwest": {
+                        "lat": 39.9493330197085,
+                        "lng": -75.16508863029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "The Capital Grille",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 1836,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/116874069144037677909\">Ed Ditlefsen</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAT6BWpYtPDZLl1E6Zb_a0QSO2qKRIVohMeaU5pOApLR2LXjumLnuyCMa0uvKlmyxCjLWfby68OYd6k0yOG9mkR6D2oc9w58mrBW-rjGRF5cElVKQnc99loPfNWzgbgDlMEhANZmsIgWnLlVkVVKPXRlLXGhQCg0y7dLOnJOKszeS54j0_Pl46ww",
+                    "width": 3264
+                }
+            ],
+            "place_id": "ChIJPxHFpi_GxokRHMsSH-o1W6E",
+            "plus_code": {
+                "compound_code": "XR2P+7H Philadelphia, PA, USA",
+                "global_code": "87F6XR2P+7H"
+            },
+            "price_level": 4,
+            "rating": 4.6,
+            "reference": "ChIJPxHFpi_GxokRHMsSH-o1W6E",
+            "scope": "GOOGLE",
+            "types": [
+                "meal_takeaway",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1310,
+            "vicinity": "1338 Chestnut Street # 46, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.91250189999999,
+                    "lng": -75.1839499
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9137983802915,
+                        "lng": -75.18248471970848
+                    },
+                    "southwest": {
+                        "lat": 39.9111004197085,
+                        "lng": -75.1851826802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/lodging-71.png",
+            "name": "Penrose Hotel Philadelphia",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 2003,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/102210271921868944211\">Radisson Hotel Philadelphia, PA</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAQR5hzKHr5Gi-OEELw85iEFPbs2BeYyr1SoR8N1Qh1rKJruzX4eeXnpVFeP9iSWitiyvldvx-mp3ZiAK6E6xw_hH_KjwrFowdZNi64HH9K4i_EAFWoX8EVD5xHJouDtskEhDG0oahTP5Dz0zC8bG-spQlGhSrmnNY6OxLE4z0LXpcvQ0_QphK6g",
+                    "width": 3000
+                }
+            ],
+            "place_id": "ChIJHT2_T9vFxokROPpXGcxKGbQ",
+            "plus_code": {
+                "compound_code": "WR78+2C Philadelphia, PA, USA",
+                "global_code": "87F6WR78+2C"
+            },
+            "rating": 2.2,
+            "reference": "ChIJHT2_T9vFxokROPpXGcxKGbQ",
+            "scope": "GOOGLE",
+            "types": [
+                "parking",
+                "lodging",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1859,
+            "vicinity": "2033 Penrose Avenue, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9501768,
+                    "lng": -75.16261009999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9515817802915,
+                        "lng": -75.16124976970849
+                    },
+                    "southwest": {
+                        "lat": 39.9488838197085,
+                        "lng": -75.1639477302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "McGillin's Olde Ale House",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 426,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/105103797310160815783\">McGillin&#39;s Olde Ale House</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAcRqAYJ049Hyd_-k3Iw6nTeAfYLh8eyVtC9JEwltC9AYMtYZwvji79iNZsxPaNr33qLlkGKYM6XHN0r6a9YcWzgAp_R2kTWtSgCnEIQzCEM1bpN7gh5A44PGdtULhyVw8EhAvTL_e7rkNN1YvSCYdCLhdGhRMHjVO1LC7I5vj6EzIj_hXp8IgAQ",
+                    "width": 640
+                }
+            ],
+            "place_id": "ChIJoYSfci_GxokRR3o-DdW78bo",
+            "plus_code": {
+                "compound_code": "XR2P+3X Philadelphia, PA, USA",
+                "global_code": "87F6XR2P+3X"
+            },
+            "price_level": 1,
+            "rating": 4.4,
+            "reference": "ChIJoYSfci_GxokRR3o-DdW78bo",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2708,
+            "vicinity": "1310 Drury Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9462581,
+                    "lng": -75.1453259
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9474591802915,
+                        "lng": -75.14460956970849
+                    },
+                    "southwest": {
+                        "lat": 39.9447612197085,
+                        "lng": -75.14730753029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Zahav",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/108252977719746439598\">Michael Palan</a>"
+                    ],
+                    "photo_reference": "CmRaAAAApVOThcifc12mQQExUJaPGDzohUJXq1RVZKo1RFahlirVZ6nDDmPU6T2XmSD11jeEWrCWFL2kZ4jV8bb3ZbY-tzT3dppOSgD4A5E6u_QsYoKOndg_7txMAhyOK35T8kKVEhAAmmGHozkGQo0sMBBTcmefGhQAxQwJ588Tv-YDuI7fBnGJB4qtQQ",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJzSVn2prIxokRx1kTchCYRwI",
+            "plus_code": {
+                "compound_code": "WVW3+GV Philadelphia, PA, USA",
+                "global_code": "87F6WVW3+GV"
+            },
+            "price_level": 3,
+            "rating": 4.7,
+            "reference": "ChIJzSVn2prIxokRx1kTchCYRwI",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1839,
+            "vicinity": "237 Saint James Place, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.94970199999999,
+                    "lng": -75.1617703
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.95111068029149,
+                        "lng": -75.16051626970849
+                    },
+                    "southwest": {
+                        "lat": 39.9484127197085,
+                        "lng": -75.1632142302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "El Vez",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 1638,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/106529184387412558829\">El Vez</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAld9yzVew9u3j5RcQw_F_w4vGbQfv_XlkSkRlOayPeKVEaLslh8LPZgrPY46-CDnGqi72XtOGh1fRLN-Jy2YdWZS9TncJ2LgDkezsD9s7fcb-Hb2ccOor8FZVcHOBTDZHEhAoOvvA-IqiUc8BsNHOmdonGhSG-lDheqWXy2hqECWRosOrMW9T0g",
+                    "width": 2048
+                }
+            ],
+            "place_id": "ChIJ6_UiaC_GxokRxRLbUmfNszM",
+            "plus_code": {
+                "compound_code": "WRXQ+V7 Philadelphia, PA, USA",
+                "global_code": "87F6WRXQ+V7"
+            },
+            "price_level": 2,
+            "rating": 4.5,
+            "reference": "ChIJ6_UiaC_GxokRxRLbUmfNszM",
+            "scope": "GOOGLE",
+            "types": [
+                "meal_takeaway",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 3438,
+            "vicinity": "121 South 13th Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9531992,
+                    "lng": -75.160217
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9544491802915,
+                        "lng": -75.1587762697085
+                    },
+                    "southwest": {
+                        "lat": 39.9517512197085,
+                        "lng": -75.1614742302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Maggiano's Little Italy",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/117968101242248727248\">Natasha Taylor</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAO5v-s2t9RP_NM_dJncscI5Kt51PRHYUBKNdCdCoXKcFmj0wqdD6onIK57jPXqJr-_UZEfmZ48kKHxbMdi1_P4nPINaWeIf3suhL4yPWYlPXBhTK74pjEHGPt-7Ot7dUKEhBTqrWUkfD_K6WVv4fQkWgtGhTBFrSjpSXg5TG9Nb9DpEDc7m7snQ",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJIVGRTSnGxokR6t2cdmm0TJ0",
+            "plus_code": {
+                "compound_code": "XR3Q+7W Philadelphia, PA, USA",
+                "global_code": "87F6XR3Q+7W"
+            },
+            "price_level": 2,
+            "rating": 4.4,
+            "reference": "ChIJIVGRTSnGxokR6t2cdmm0TJ0",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "bar",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2933,
+            "vicinity": "1201 Filbert Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.92107540000001,
+                    "lng": -75.1450699
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9224221802915,
+                        "lng": -75.1437558197085
+                    },
+                    "southwest": {
+                        "lat": 39.9197242197085,
+                        "lng": -75.14645378029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "John's Roast Pork",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/103227317714156439562\">Matthew Paulini</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAq_FeVgqNcrOjgMF5N-pTU5dfQb2KuA_MsyMujMrVB9AnNZIgCZC9ygMDss-2DVokE2RZVbUttGf9YyTSQhXOPLkf8dnIO92Lxb5XPmR6dKCVQ2N7Xr2wgAP8cu4REBStEhDD0BtDfu0jHNy5CWDVyxZ-GhTCWusx1u6Hk7d6AKND5p8ofiHfyA",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJ05d0L6zIxokRLMJrYW1wRY4",
+            "plus_code": {
+                "compound_code": "WVC3+CX Philadelphia, PA, USA",
+                "global_code": "87F6WVC3+CX"
+            },
+            "price_level": 1,
+            "rating": 4.6,
+            "reference": "ChIJ05d0L6zIxokRLMJrYW1wRY4",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2369,
+            "vicinity": "14 Snyder Avenue, Philadelphia"
+        },
+        {
+            "business_status": "CLOSED_TEMPORARILY",
+            "geometry": {
+                "location": {
+                    "lat": 39.9503667,
+                    "lng": -75.163242
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9519241802915,
+                        "lng": -75.16190866970851
+                    },
+                    "southwest": {
+                        "lat": 39.9492262197085,
+                        "lng": -75.16460663029152
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/generic_business-71.png",
+            "name": "Lucky Strike Philadelphia",
+            "permanently_closed": true,
+            "photos": [
+                {
+                    "height": 328,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/109762841563829404009\">Lucky Strike Philadelphia</a>"
+                    ],
+                    "photo_reference": "CmRaAAAA2CxF3cvbGbYUU0mBWl-srgPnbA84bATc-M11nqlIyvaCWyVcj13mqGsmhK38Bmfp_pMNJbsCZqO5yiYvN6TTK-HiOJVjxbRoaMoraO373EByu_p-2u-K2Hlub10N1R6FEhDpcls5j6MeXqBmpl7u5F0FGhTs54R8piota0hywxkuqI2ajGVi6w",
+                    "width": 930
+                }
+            ],
+            "place_id": "ChIJyZOuoC_GxokRWHXIIQsXPIU",
+            "plus_code": {
+                "compound_code": "XR2P+4P Philadelphia, PA, USA",
+                "global_code": "87F6XR2P+4P"
+            },
+            "price_level": 1,
+            "rating": 4.2,
+            "reference": "ChIJyZOuoC_GxokRWHXIIQsXPIU",
+            "scope": "GOOGLE",
+            "types": [
+                "bowling_alley",
+                "night_club",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1093,
+            "vicinity": "1336 Chestnut Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9471385,
+                    "lng": -75.1445506
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.94851233029151,
+                        "lng": -75.14310156970849
+                    },
+                    "southwest": {
+                        "lat": 39.94581436970851,
+                        "lng": -75.1457995302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "City Tavern Restaurant",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 1580,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/114997233408094925591\">City Tavern Restaurant</a>"
+                    ],
+                    "photo_reference": "CmRZAAAAGpD6W_NZP31RUaN8jtpHCMjvHMaq9Wu5aZ9_zGHwHB6ss430ozdgEivwV9M1J1Neie8pCVjGSrb64lb-ucccXqdEdIB8xoLRmwDjXoqWSvIk9WsmgC8Th4i2zGLRZ7N4EhBeY9kSzxRKz7ulEX834egkGhRl2JQ0fnf2Wt9P29ynjO6Vx4-2Eg",
+                    "width": 1191
+                }
+            ],
+            "place_id": "ChIJnxG8QIXIxokRl4xKib7ruLI",
+            "plus_code": {
+                "compound_code": "WVW4+V5 Philadelphia, PA, USA",
+                "global_code": "87F6WVW4+V5"
+            },
+            "price_level": 3,
+            "rating": 4.5,
+            "reference": "ChIJnxG8QIXIxokRl4xKib7ruLI",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1504,
+            "vicinity": "138 South 2nd Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.94912219999999,
+                    "lng": -75.170749
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.95050948029149,
+                        "lng": -75.1694686197085
+                    },
+                    "southwest": {
+                        "lat": 39.94781151970849,
+                        "lng": -75.17216658029152
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Parc",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 471,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/109507109097688419440\">Parc</a>"
+                    ],
+                    "photo_reference": "CmRaAAAApAo3pUjnMdBu0RNcBNFxrrZS_aspgq7vQ58EtULsQTDIoHrg4GzQGETpmJT9NLrFHhyqfkj1N8rzm3Z7hY1U2oTJkk2UYLMWGTXXUO-FsuQkwYtfT3A7PC07p4zEQ_eZEhDmR-O3Z7h-1Q3Oxxo7q7HlGhQDw7yHfNjeoPO9oaECFY81cr2Hyw",
+                    "width": 706
+                }
+            ],
+            "place_id": "ChIJGWwTFDrGxokRql6htA1qib4",
+            "plus_code": {
+                "compound_code": "WRXH+JP Philadelphia, PA, USA",
+                "global_code": "87F6WRXH+JP"
+            },
+            "price_level": 3,
+            "rating": 4.6,
+            "reference": "ChIJGWwTFDrGxokRql6htA1qib4",
+            "scope": "GOOGLE",
+            "types": [
+                "meal_takeaway",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 3004,
+            "vicinity": "227 South 18th Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9513999,
+                    "lng": -75.17377379999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.95269908029151,
+                        "lng": -75.1723552697085
+                    },
+                    "southwest": {
+                        "lat": 39.95000111970851,
+                        "lng": -75.17505323029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Village Whiskey",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 1371,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/118016725804972697430\">Village Whiskey</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAEHLSNLr7nRNh-j4J7mklRFv5zW5PYAjolVATIHI5ba8v-5IjulKQKQYkAwh9t2wO4AM871X1Uc-zP2RcDrGlZUrdZJZgGw5VbeJGj7_o_AVJx1QcpFVAfLr9Hr0lp7gpEhCJS4HcgIyr1ZAYqgpNNEJDGhSJfDfrnMKNb33FhcaNZcXlvC91Yw",
+                    "width": 2048
+                }
+            ],
+            "place_id": "ChIJLfhKaTfGxokRiOZL6x398WY",
+            "plus_code": {
+                "compound_code": "XR2G+HF Philadelphia, PA, USA",
+                "global_code": "87F6XR2G+HF"
+            },
+            "price_level": 2,
+            "rating": 4.4,
+            "reference": "ChIJLfhKaTfGxokRiOZL6x398WY",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 982,
+            "vicinity": "118 South 20th Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9690372,
+                    "lng": -75.13432299999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.97033763029149,
+                        "lng": -75.1330074697085
+                    },
+                    "southwest": {
+                        "lat": 39.9676396697085,
+                        "lng": -75.13570543029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/bar-71.png",
+            "name": "Johnny Brenda's",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 4032,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/103118252001831850755\">alex courtney</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAEq9ryz0I22sAcv2x3gLmJu_iQFAyiXLj88M7TBiReHykl_8i3I0Sap6EzY8PkVij3i47w6oBJfnDORzuH0maJjfVvS2keP-Km5MZ5VKCD8-BAOBtx6bDciKN566Da8xYEhADbMu85gcoaSF0f0B3dgBIGhRfblp1GI1lArqjkt9rIxqv8Im-DQ",
+                    "width": 3024
+                }
+            ],
+            "place_id": "ChIJS9ygjXvGxokREtJ_5jT7A5Q",
+            "plus_code": {
+                "compound_code": "XV98+J7 Philadelphia, PA, USA",
+                "global_code": "87F6XV98+J7"
+            },
+            "price_level": 2,
+            "rating": 4.5,
+            "reference": "ChIJS9ygjXvGxokREtJ_5jT7A5Q",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1331,
+            "vicinity": "1201 Frankford Avenue, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.95003699999999,
+                    "lng": -75.1625129
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9513267302915,
+                        "lng": -75.16121506970849
+                    },
+                    "southwest": {
+                        "lat": 39.9486287697085,
+                        "lng": -75.1639130302915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/bar-71.png",
+            "name": "Time",
+            "opening_hours": {
+                "open_now": false
+            },
+            "photos": [
+                {
+                    "height": 1055,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/106576016118950911961\">Time</a>"
+                    ],
+                    "photo_reference": "CmRZAAAAdcwTrI_dsW0DVvoMjWCWE_WK1YIP-FTjnW1zJWYWTd2oWR36H1DIe1IHt30goT5SLtgs8d9VlGm-yPJ29-KDelamj0GUbZNpNNuHWVFFBjvD9SaOzYAAbwA6avCp7UbCEhCv3HpJxJJpmFp36IMERGiUGhT-GFp1doSN-pT_ttUl6LLMDdJMvA",
+                    "width": 2048
+                }
+            ],
+            "place_id": "ChIJjRoEci_GxokRQKayshr-5EU",
+            "plus_code": {
+                "compound_code": "XR2P+2X Philadelphia, PA, USA",
+                "global_code": "87F6XR2P+2X"
+            },
+            "price_level": 2,
+            "rating": 4.4,
+            "reference": "ChIJjRoEci_GxokRQKayshr-5EU",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "night_club",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1087,
+            "vicinity": "1315 Sansom Street, Philadelphia"
+        },
+        {
+            "business_status": "CLOSED_TEMPORARILY",
+            "geometry": {
+                "location": {
+                    "lat": 39.9520673,
+                    "lng": -75.1851726
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9533609302915,
+                        "lng": -75.18381081970848
+                    },
+                    "southwest": {
+                        "lat": 39.9506629697085,
+                        "lng": -75.1865087802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/generic_business-71.png",
+            "name": "World Cafe Live Philadelphia",
+            "permanently_closed": true,
+            "photos": [
+                {
+                    "height": 2988,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/103447036128752097272\">Jessica Marie</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAIuo-pBZcKbKIndptk7cidtRT9xz_BUzkmDRVmTolm6N-d3Duu26rSSBek6xFbheBBgRzDFWhm5DZC6UIpUuwqaLEd6Ot_NB_y14VMyo9r6KEnoQQm0kdKLOJ8piI7GYHEhDPNaCYiBd3UOtCyZvoT32jGhQWzfrY1DmpJWcX3D8vjQvKXylsAA",
+                    "width": 5312
+                }
+            ],
+            "place_id": "ChIJ7RhuX0_GxokRjL5qFrDINys",
+            "plus_code": {
+                "compound_code": "XR27+RW Philadelphia, PA, USA",
+                "global_code": "87F6XR27+RW"
+            },
+            "price_level": 2,
+            "rating": 4.7,
+            "reference": "ChIJ7RhuX0_GxokRjL5qFrDINys",
+            "scope": "GOOGLE",
+            "types": [
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1415,
+            "vicinity": "3025 Walnut Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.947701,
+                    "lng": -75.16812399999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9490367302915,
+                        "lng": -75.16669421970848
+                    },
+                    "southwest": {
+                        "lat": 39.9463387697085,
+                        "lng": -75.1693921802915
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Monk's Cafe",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 432,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/113644057757612169391\">Monk&#39;s Cafe</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAc8Ii07bNDOxFk4pEObqXBj3-6rYWQ68XvdyBx9HNYYKHUtmdzKB_rP8w7kan8i-CSlsjko8l2Jy8j2f9KVjTMohxX782zDo0aDRM9FNZPTJSntNY_mc9X2V346oODTfqEhAuhkR6-8aqSah8BTgOC6BnGhS0AdRNU-WpibVp_zVUarJdzc_NRQ",
+                    "width": 600
+                }
+            ],
+            "place_id": "ChIJo8Mj5DrGxokRzOysJp3HPrw",
+            "plus_code": {
+                "compound_code": "WRXJ+3Q Philadelphia, PA, USA",
+                "global_code": "87F6WRXJ+3Q"
+            },
+            "price_level": 2,
+            "rating": 4.6,
+            "reference": "ChIJo8Mj5DrGxokRzOysJp3HPrw",
+            "scope": "GOOGLE",
+            "types": [
+                "cafe",
+                "bar",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2683,
+            "vicinity": "264 South 16th Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9415536,
+                    "lng": -75.1493134
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.94294598029149,
+                        "lng": -75.1479675197085
+                    },
+                    "southwest": {
+                        "lat": 39.9402480197085,
+                        "lng": -75.15066548029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Jim's South St. (Jim's Steaks South Street)",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3024,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/111337232050348886467\">B. H.</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAScCB3VbFxOLFG-0RvhAH3JCMgbDQamYO62t5OG9ovv8Sz3LF766-p8f412URsDfMolDS5apvFa9SLtgMpN0cfATQgJHHNyMkBnU0FZj5kFdhxWAD9oCqPaFxG6fjl42REhD0tydGHzzgspFA2zpjmzsjGhShgB6gRSgHfm-BnHYGhEsXSNHN1w",
+                    "width": 4032
+                }
+            ],
+            "place_id": "ChIJMfVOsJ7IxokRKNz9ctvYNG4",
+            "plus_code": {
+                "compound_code": "WVR2+J7 Philadelphia, PA, USA",
+                "global_code": "87F6WVR2+J7"
+            },
+            "price_level": 1,
+            "rating": 4.4,
+            "reference": "ChIJMfVOsJ7IxokRKNz9ctvYNG4",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 7777,
+            "vicinity": "400 South Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.9535582,
+                    "lng": -75.1929054
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.9549786302915,
+                        "lng": -75.19156981970849
+                    },
+                    "southwest": {
+                        "lat": 39.9522806697085,
+                        "lng": -75.19426778029151
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "White Dog Cafe",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 270,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/102574919425333161365\">White Dog Cafe</a>"
+                    ],
+                    "photo_reference": "CmRaAAAAVQowFoJ_4KgRy8LL_XqsdKsfNKffrIj4MAKvBd2aBzLVIE8ch6DcjgBxokOvvQdh8e84sLaUraIg2MfcJOGaqyKJbvqb475fz_HzrxblgxnHI2314XIlVN9BEM54vZCSEhCw_4VjrWqxDkGaO0Rk13A7GhQFpnfEAP39QHVsHQwsUkW0FUrXbA",
+                    "width": 480
+                }
+            ],
+            "place_id": "ChIJA9BZj1DGxokRIn0q5RahK9o",
+            "plus_code": {
+                "compound_code": "XR34+CR Philadelphia, PA, USA",
+                "global_code": "87F6XR34+CR"
+            },
+            "price_level": 3,
+            "rating": 4.4,
+            "reference": "ChIJA9BZj1DGxokRIn0q5RahK9o",
+            "scope": "GOOGLE",
+            "types": [
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 1273,
+            "vicinity": "3420 Sansom Street, Philadelphia"
+        },
+        {
+            "business_status": "OPERATIONAL",
+            "geometry": {
+                "location": {
+                    "lat": 39.960273,
+                    "lng": -75.16870639999999
+                },
+                "viewport": {
+                    "northeast": {
+                        "lat": 39.96169853029149,
+                        "lng": -75.16731901970849
+                    },
+                    "southwest": {
+                        "lat": 39.95900056970849,
+                        "lng": -75.17001698029149
+                    }
+                }
+            },
+            "icon": "https://maps.gstatic.com/mapfiles/place_api/icons/restaurant-71.png",
+            "name": "Sabrina's Cafe & Spencer's Too",
+            "opening_hours": {
+                "open_now": true
+            },
+            "photos": [
+                {
+                    "height": 3744,
+                    "html_attributions": [
+                        "<a href=\"https://maps.google.com/maps/contrib/111837431684383707903\">Sabrina&#39;s Cafe &amp; Spencer&#39;s Too</a>"
+                    ],
+                    "photo_reference": "CmRaAAAARgO17UrZhBFBqn7rH902l_olEWrkvB4gmC2VArXV_Ngrj8bamJpw5jilrHsgGIEp02fGTDuDEHasPf0z2b8CXKRXZ9QZsUXlHyfwfzeTYw-wG9w6_9o4Ju_9B73jm-y6EhB6VS3c38TCAA-Q2_BBiyXfGhQGcFgBT8vIKWnQSfHLyk9CEiC77w",
+                    "width": 5616
+                }
+            ],
+            "place_id": "ChIJxV6oLs3HxokRAzDNE-V7_pQ",
+            "plus_code": {
+                "compound_code": "XR6J+4G Philadelphia, PA, USA",
+                "global_code": "87F6XR6J+4G"
+            },
+            "price_level": 2,
+            "rating": 4.5,
+            "reference": "ChIJxV6oLs3HxokRAzDNE-V7_pQ",
+            "scope": "GOOGLE",
+            "types": [
+                "cafe",
+                "restaurant",
+                "food",
+                "point_of_interest",
+                "establishment"
+            ],
+            "user_ratings_total": 2028,
+            "vicinity": "1804 Callowhill Street, Philadelphia"
+        }
+    ],
+    "status": "OK"
+}


### PR DESCRIPTION
it returns a promise with a list of the restaurant objects, and within them we have fields we need exactly like the pojos have them, so it can be directly converted to the pojo. This is how to use it:





//the import in whatever place you need to use it
import { GoogleMapsConnectionService } from './app/services/google-maps-connection.service';

 let gmcs = new GoogleMapsConnectionService;

//replace 'new york' with 'philadelphia' to get the other option we have available at the time
gmcs.getRestaurants('new york')
    .then({



      // do what you need to do. for example 'response[0].name'
      // provides the name of first restaurant in the list, would likely provide
      // the stuff to convert it to a pojo here



});
